### PR TITLE
Support short names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - php: 5.6
       env: DB=MYSQL PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_TEST=1 PHPUNIT_COVERAGE_TEST=1
+      env: DB=MYSQL PHPCS_TEST=1 PHPUNIT_COVERAGE_TEST=1
 
 before_script:
   - phpenv rehash
@@ -23,11 +23,12 @@ before_script:
   - composer install --prefer-dist
   - composer require --prefer-dist --no-update silverstripe/recipe-core:1.0.x-dev
   - composer require --prefer-dist --no-update squizlabs/php_codesniffer:*
+  - vendor/bin/sake dev/build flush=all
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit ideannotator/tests/; fi
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then phpdbg -qrr vendor/bin/phpunit --coverage-clover=coverage.xml; fi
-  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=vendor/silverstripe/framework/phpcs.xml.dist ideannotator/src/ ; fi
+  - if [[ $PHPCS_TEST ]]; then vendor/bin/phpcs --standard=ideannotator/phpcs.xml.dist ideannotator/src/ ; fi
 
 after_success:
   - if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi

--- a/Changelog.md
+++ b/Changelog.md
@@ -33,3 +33,12 @@
 
 # 3.0 beta-1
 * Support for SilverStripe 4
+
+# 3.0 rc-1
+* Updated support for SilverStripe 4
+* Added support for the `through` method
+
+# 3.0 rc-2
+* Fixed bug trimming too much whitespace in rc-1
+* Support for short classnames instead of FQN
+* ~~require_once in tests no longer needed~~ Nope, still needed

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Martijn van Nieuwenhoven
+Copyright (c) 2015-2018, Martijn van Nieuwenhoven/SilverLeague
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -3,7 +3,7 @@ Name: ideannotator
 ---
 SilverStripe\Dev\DevBuildController:
   extensions:
-    - SilverLeague\IDEAnnotator\Annotatable
+    - SilverLeague\IDEAnnotator\Extensions\Annotatable
 SilverLeague\IDEAnnotator\DataObjectAnnotator:
     enabled_modules:
       - mysite

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
   "require-dev": {
     "scriptfusion/phpunit-immediate-exception-printer": "^1",
     "phpunit/phpunit": "^5.7",
+    "silverstripe/recipe-cms": "~1",
     "squizlabs/php_codesniffer": "3.*"
   },
   "autoload": {

--- a/docs/en/Installation.md
+++ b/docs/en/Installation.md
@@ -53,3 +53,24 @@ SilverLeague\IDEAnnotator\DataObjectAnnotator:
       - mysite
       - SilverLeague/IDEAnnotator
 ```
+
+If you don't want to use fully qualified classnames, you can configure that like so:
+
+```yaml
+
+---
+Only:
+    environment: 'dev'
+---
+SilverLeague\IDEAnnotator\DataObjectAnnotator:
+    enabled: true
+    use_short_name: true
+    enabled_modules:
+      - mysite
+```
+
+**NOTE**
+
+- Using short names, will also shorten core names like `ManyManyList`, you'll have to adjust your use statements to work.
+
+- If you change the usage of short names halfway in your project, you may need to clear out all your docblocks before regenerating

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="SilverStripe">
+    <description>CodeSniffer ruleset for SilverStripe coding conventions.</description>
+
+    <!-- base rules are PSR-2 -->
+    <rule ref="PSR2">
+        <!-- Current exclusions -->
+        <exclude name="PSR1.Methods.CamelCapsMethodName"/>
+        <exclude name="PSR1.Files.SideEffects.FoundWithSymbols"/>
+        <exclude name="PSR2.Classes.PropertyDeclaration"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration"/> <!-- causes php notice while linting -->
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenercase"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.WrongOpenerdefault"/>
+        <exclude name="PSR2.ControlStructures.SwitchDeclaration.TerminatingComment"/>
+        <exclude name="PSR2.Methods.MethodDeclaration.Underscore"/>
+        <exclude name="Squiz.Scope.MethodScope"/>
+        <exclude name="Squiz.Classes.ValidClassName.NotCamelCaps"/>
+        <exclude name="Generic.Files.LineLength.TooLong"/>
+        <exclude name="PEAR.Functions.ValidDefaultValue.NotAtEnd"/>
+    </rule>
+    <rule phpcbf-only="true" ref="Squiz.Strings.ConcatenationSpacing">
+        <properties>
+            <property name="spacing" value="1"/>
+            <property name="ignoreNewlines" value="true"/>
+        </properties>
+    </rule>
+
+    <!-- include php files only -->
+    <arg name="extensions" value="php,lib,inc,php5"/>
+</ruleset>
+

--- a/src/DataObjectAnnotator.php
+++ b/src/DataObjectAnnotator.php
@@ -234,6 +234,7 @@ class DataObjectAnnotator
      *
      * @param string $className
      * @return bool
+     * @throws \InvalidArgumentException
      * @throws ReflectionException
      * @throws NotFoundExceptionInterface
      */

--- a/src/Extensions/Annotatable.php
+++ b/src/Extensions/Annotatable.php
@@ -9,6 +9,7 @@ use SilverLeague\IDEAnnotator\Helpers\AnnotatePermissionChecker;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\DevBuildController;
 
 /**
  * Class Annotatable
@@ -17,7 +18,7 @@ use SilverStripe\Core\Injector\Injector;
  * Start annotation, if skipannotation is not set and the annotator is enabled.
  *
  * @package IDEAnnotator/Extensions
- * @property \SilverStripe\Dev\DevBuildController|\SilverLeague\IDEAnnotator\Annotatable $owner
+ * @property DevBuildController|Annotatable $owner
  */
 class Annotatable extends Extension
 {

--- a/src/Generators/ControllerTagGenerator.php
+++ b/src/Generators/ControllerTagGenerator.php
@@ -2,7 +2,6 @@
 
 namespace SilverLeague\IDEAnnotator\Generators;
 
-use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;
 use ReflectionException;
 use SilverStripe\CMS\Controllers\ContentController;
@@ -13,7 +12,7 @@ class ControllerTagGenerator extends AbstractTagGenerator
 
     /**
      * @return void
-     * @throws NotFoundExceptionInterface
+     * @throws ReflectionException
      */
     protected function generateTags()
     {

--- a/src/Generators/ControllerTagGenerator.php
+++ b/src/Generators/ControllerTagGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverLeague\IDEAnnotator;
+namespace SilverLeague\IDEAnnotator\Generators;
 
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionClass;
@@ -22,16 +22,23 @@ class ControllerTagGenerator extends AbstractTagGenerator
         $this->generateOwnerTags();
     }
 
+    /**
+     * Generate the controller tags, these differ slightly from the standard ORM tags
+     *
+     * @throws ReflectionException
+     */
     protected function generateControllerObjectTags()
     {
         $pageClassname = str_replace(['_Controller', 'Controller'], '', $this->className);
         if (class_exists($pageClassname) && $this->isContentController($this->className)) {
-            $this->pushPropertyTag("\\$pageClassname" . ' dataRecord');
-            $this->pushMethodTag($pageClassname, "\\$pageClassname" . ' data()');
+            $pageClassname = $this->getAnnotationClassName($pageClassname);
+
+            $this->pushPropertyTag($pageClassname . ' dataRecord');
+            $this->pushMethodTag('data()', $pageClassname . ' data()');
 
             // don't mixin Page, since this is a ContentController method
             if ($pageClassname !== 'Page') {
-                $this->pushMixinTag("\\$pageClassname");
+                $this->pushMixinTag($pageClassname);
             }
         }
     }

--- a/src/Generators/DocBlockGenerator.php
+++ b/src/Generators/DocBlockGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverLeague\IDEAnnotator;
+namespace SilverLeague\IDEAnnotator\Generators;
 
 use InvalidArgumentException;
 use LogicException;
@@ -70,7 +70,7 @@ class DocBlockGenerator
      *
      * If we file old style generated docblocks we remove them
      *
-     * @return string
+     * @return bool|string
      */
     public function getExistingDocBlock()
     {
@@ -139,13 +139,5 @@ class DocBlockGenerator
     public function getGeneratedTags()
     {
         return $this->tagGenerator->getTags();
-    }
-
-    /**
-     * @return array
-     */
-    public function getExistingTagComments()
-    {
-        return $this->tagGenerator->getExistingTagComments();
     }
 }

--- a/src/Generators/OrmTagGenerator.php
+++ b/src/Generators/OrmTagGenerator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverLeague\IDEAnnotator;
+namespace SilverLeague\IDEAnnotator\Generators;
 
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataList;
@@ -100,7 +100,10 @@ class OrmTagGenerator extends AbstractTagGenerator
         if ($fields = (array)$this->getClassConfig('belongs_to')) {
             foreach ($fields as $fieldName => $dataObjectName) {
                 $dataObjectName = $this->resolveDotNotation($dataObjectName);
-                $this->pushMethodTag($fieldName, "\\{$dataObjectName} {$fieldName}()");
+                $dataObjectName = $this->getAnnotationClassName($dataObjectName);
+                $tagString = "{$dataObjectName} {$fieldName}()";
+
+                $this->pushMethodTag($fieldName, $tagString);
             }
         }
     }
@@ -124,7 +127,10 @@ class OrmTagGenerator extends AbstractTagGenerator
         if ($fields = (array)$this->getClassConfig('has_one')) {
             foreach ($fields as $fieldName => $dataObjectName) {
                 $this->pushPropertyTag("int \${$fieldName}ID");
-                $this->pushMethodTag($fieldName, "\\{$dataObjectName} {$fieldName}()");
+                $dataObjectName = $this->getAnnotationClassName($dataObjectName);
+                $tagString = "{$dataObjectName} {$fieldName}()";
+
+                $this->pushMethodTag($fieldName, $tagString);
             }
         }
     }
@@ -145,12 +151,17 @@ class OrmTagGenerator extends AbstractTagGenerator
     {
         if (!empty($fields)) {
             foreach ((array)$fields as $fieldName => $dataObjectName) {
+                $fieldName = trim($fieldName);
                 // A many_many with a relation through another DataObject
                 if (is_array($dataObjectName)) {
                     $dataObjectName = $dataObjectName['through'];
                 }
                 $dataObjectName = $this->resolveDotNotation($dataObjectName);
-                $this->pushMethodTag($fieldName, "\\{$listType}|\\{$dataObjectName}[] {$fieldName}()");
+                $listName = $this->getAnnotationClassName($listType);
+                $dataObjectName = $this->getAnnotationClassName($dataObjectName);
+
+                $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
+                $this->pushMethodTag($fieldName, $tagString);
             }
         }
     }

--- a/src/Helpers/AnnotateClassInfo.php
+++ b/src/Helpers/AnnotateClassInfo.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace SilverLeague\IDEAnnotator;
+namespace SilverLeague\IDEAnnotator\Helpers;
 
 use ReflectionClass;
 use ReflectionException;
@@ -57,13 +57,5 @@ class AnnotateClassInfo
     public function getClassFilePath()
     {
         return $this->reflector->getFileName();
-    }
-
-    /**
-     * @return string
-     */
-    public function getDocComment()
-    {
-        return $this->reflector->getDocComment();
     }
 }

--- a/src/Helpers/AnnotatePermissionChecker.php
+++ b/src/Helpers/AnnotatePermissionChecker.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace SilverLeague\IDEAnnotator;
+namespace SilverLeague\IDEAnnotator\Helpers;
 
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionException;
+use SilverLeague\IDEAnnotator\DataObjectAnnotator;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\Director;
-use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ModuleManifest;
@@ -53,7 +53,7 @@ class AnnotatePermissionChecker
      */
     public function isEnabled()
     {
-        return (bool)Config::inst()->get(DataObjectAnnotator::class, 'enabled');
+        return (bool)DataObjectAnnotator::config()->get('enabled');
     }
 
     /**
@@ -80,9 +80,12 @@ class AnnotatePermissionChecker
         if ($this->classNameIsSupported($className)) {
             $classInfo = new AnnotateClassInfo($className);
             $filePath = $classInfo->getClassFilePath();
-            $module = Injector::inst()->createWithArgs(ModuleManifest::class, [Director::baseFolder()])->getModuleByPath($filePath);
+            $module = Injector::inst()->createWithArgs(
+                ModuleManifest::class,
+                [Director::baseFolder()]
+            )->getModuleByPath($filePath);
 
-            $allowedModules = (array)Config::inst()->get(DataObjectAnnotator::class, 'enabled_modules');
+            $allowedModules = (array)DataObjectAnnotator::config()->get('enabled_modules');
 
             return in_array($module->getName(), $allowedModules, true);
         }
@@ -125,7 +128,7 @@ class AnnotatePermissionChecker
      */
     public function enabledModules()
     {
-        $enabled = (array)Config::inst()->get(DataObjectAnnotator::class, 'enabled_modules');
+        $enabled = (array)DataObjectAnnotator::config()->get('enabled_modules');
 
         // modules might be enabled more then once.
         return array_combine($enabled, $enabled);

--- a/src/Tasks/DataObjectAnnotatorTask.php
+++ b/src/Tasks/DataObjectAnnotatorTask.php
@@ -1,9 +1,11 @@
 <?php
 
-namespace SilverLeague\IDEAnnotator;
+namespace SilverLeague\IDEAnnotator\Tasks;
 
 use Psr\Container\NotFoundExceptionInterface;
 use ReflectionException;
+use SilverLeague\IDEAnnotator\DataObjectAnnotator;
+use SilverLeague\IDEAnnotator\Helpers\AnnotatePermissionChecker;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\BuildTask;
@@ -26,8 +28,10 @@ class DataObjectAnnotatorTask extends BuildTask
     {
         parent::__construct();
         $this->title = 'DataObject annotations for specific DataObjects, Extensions or Controllers';
-        $this->description = "DataObject Annotator annotates your DO's if possible, helping you write better code.<br />"
-            . 'Usage: add the module or DataObject as parameter to the URL, e.g. ?module=mysite .';
+        $this->description = "DataObject Annotator annotates your DO's if possible," .
+            " helping you write better code." .
+            "<br />Usage: add the module or DataObject as parameter to the URL," .
+            " e.g. ?module=mysite .";
     }
 
     /**

--- a/src/Tasks/DataObjectAnnotatorTask.php
+++ b/src/Tasks/DataObjectAnnotatorTask.php
@@ -28,10 +28,11 @@ class DataObjectAnnotatorTask extends BuildTask
     {
         parent::__construct();
         $this->title = 'DataObject annotations for specific DataObjects, Extensions or Controllers';
-        $this->description = "DataObject Annotator annotates your DO's if possible," .
-            " helping you write better code." .
-            "<br />Usage: add the module or DataObject as parameter to the URL," .
-            " e.g. ?module=mysite .";
+
+        $this->description = 'DataObject Annotator annotates your DO\'s if possible,' .
+            ' helping you write better code.' .
+            '<br />Usage: add the module or DataObject as parameter to the URL,' .
+            ' e.g. ?module=mysite';
     }
 
     /**

--- a/tests/mock/AnnotatorPageTest.php
+++ b/tests/mock/AnnotatorPageTest.php
@@ -3,9 +3,12 @@
 namespace SilverLeague\IDEAnnotator\Tests;
 
 // Why is this required?
-// @todo get it to work properly
-require_once(BASE_PATH . '/mysite/code/Page.php');
-require_once(BASE_PATH . '/mysite/code/PageController.php');
+// @todo get it to work properly. Seems something is wrong with the installation of the CMS
+// We do need the CMS and the pages for proper testing
+if (!class_exists('\\Page')) {
+    require_once(BASE_PATH . '/mysite/code/Page.php');
+    require_once(BASE_PATH . '/mysite/code/PageController.php');
+}
 
 use Page;
 use PageController;

--- a/tests/mock/DataObjectAnnotatorTest_Player.php
+++ b/tests/mock/DataObjectAnnotatorTest_Player.php
@@ -2,8 +2,8 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverStripe\Security\Member;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\Security\Member;
 
 /**
  * Class Player
@@ -13,6 +13,11 @@ class Player extends Member implements TestOnly
     private static $db = [
         'IsRetired'   => 'Boolean',
         'ShirtNumber' => 'Varchar',
+        'Shirt'       => 'Varchar(10)'
+    ];
+
+    private static $belongs_to = [
+        'CaptainTeam' => Team::class
     ];
 
     private static $has_one = [

--- a/tests/mock/DataObjectAnnotatorTest_Team.php
+++ b/tests/mock/DataObjectAnnotatorTest_Team.php
@@ -21,7 +21,9 @@ class Team extends DataObject implements TestOnly
     private static $db = [
         'Title'      => 'Varchar',
         'VisitCount' => 'Int',
-        'Price'      => 'Currency'
+        'Price'      => 'Currency',
+        'Dudette'    => 'Varchar',
+        'Dude'       => 'Varchar',
     ];
 
     private static $has_one = [

--- a/tests/mock/DataObjectAnnotatorTest_TeamChanged.php
+++ b/tests/mock/DataObjectAnnotatorTest_TeamChanged.php
@@ -2,9 +2,8 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverStripe\Core\Config\Config;
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 /**
  * Class DataObjectAnnotatorTest_Team

--- a/tests/mock/DataObjectAnnotatorTest_TeamComment.php
+++ b/tests/mock/DataObjectAnnotatorTest_TeamComment.php
@@ -2,8 +2,8 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 class TeamComment extends DataObject implements TestOnly
 {

--- a/tests/mock/DataObjectAnnotatorTest_TeamSupporter.php
+++ b/tests/mock/DataObjectAnnotatorTest_TeamSupporter.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace SilverLeague\IDEAnnotator\Tests;
 
 use SilverStripe\Dev\TestOnly;

--- a/tests/mock/DataObjectAnnotatorTest_Team_Extension.php
+++ b/tests/mock/DataObjectAnnotatorTest_Team_Extension.php
@@ -2,8 +2,8 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverStripe\ORM\DataExtension;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataExtension;
 
 class Team_Extension extends DataExtension implements TestOnly
 {

--- a/tests/mock/DocBlockMockWithDocBlock.php
+++ b/tests/mock/DocBlockMockWithDocBlock.php
@@ -2,7 +2,6 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use \Page;
 use SilverStripe\Dev\TestOnly;
 use SilverStripe\ORM\DataObject;
 
@@ -30,33 +29,5 @@ class OtherDocBlockMockWithDocBlock extends DataObject implements TestOnly
      */
     private static $db = [
         'Name' => 'Varchar(255)'
-    ];
-}
-
-/**
- * StartGeneratedWithDataObjectAnnotator
- *
- * @property string $Street
- * @property int $Nr
- * @property int $PageID
- * @method Page Page()
- *
- * EndGeneratedWithDataObjectAnnotator
- */
-class DataObjectWithOldStyleTagMarkers extends DataObject implements TestOnly
-{
-    /**
-     * @var array
-     */
-    private static $db = [
-        'Street' => 'Varchar(255)',
-        'Nr'     => 'Int'
-    ];
-
-    /**
-     * @var array
-     */
-    private static $has_one = [
-        'Page' => Page::class
     ];
 }

--- a/tests/mock/DoubleDataObjectInOneFile.php
+++ b/tests/mock/DoubleDataObjectInOneFile.php
@@ -2,8 +2,8 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverStripe\ORM\DataObject;
 use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
 
 class DoubleDataObjectInOneFile1 extends DataObject implements TestOnly
 {

--- a/tests/unit/AnnotatableTest.php
+++ b/tests/unit/AnnotatableTest.php
@@ -2,9 +2,12 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverLeague\IDEAnnotator\Annotatable;
-use SilverLeague\IDEAnnotator\AnnotatePermissionChecker;
 use SilverLeague\IDEAnnotator\DataObjectAnnotator;
+use SilverLeague\IDEAnnotator\Extensions\Annotatable;
+use SilverLeague\IDEAnnotator\Helpers\AnnotatePermissionChecker;
+use SilverStripe\Control\Controller;
+use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Core\Environment;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Dev\SapphireTest;
 
@@ -16,10 +19,11 @@ class AnnotatableTest extends SapphireTest
      */
     protected $extension;
 
-    protected function setUp()
+    public function testSetUp()
     {
-        parent::setUp();
-        $this->extension = Injector::inst()->get(Annotatable::class);
+        $this->extension->setUp();
+        $this->assertInstanceOf(DataObjectAnnotator::class, $this->extension->getAnnotator());
+        $this->assertInstanceOf(AnnotatePermissionChecker::class, $this->extension->getPermissionChecker());
     }
 
     public function testOutput()
@@ -28,10 +32,68 @@ class AnnotatableTest extends SapphireTest
         $this->expectOutputString("\nHello world\n\n");
     }
 
-    public function testSetUp()
+    public function testDisplayEndMessage()
     {
-        $this->extension->setUp();
-        $this->assertInstanceOf(DataObjectAnnotator::class, $this->extension->getAnnotator());
-        $this->assertInstanceOf(AnnotatePermissionChecker::class, $this->extension->getPermissionChecker());
+        $this->extension->displayMessage('Hello world', true, true);
+        $this->expectOutputString("\nHELLO WORLD");
+    }
+
+    public function testDisplayHeaderMessage()
+    {
+        $this->extension->displayMessage('Hello world', true);
+        $this->expectOutputString("\nHELLO WORLD\n\n");
+    }
+
+    public function testAfterCallActionHandlerRequestBlock()
+    {
+        $request = new HTTPRequest('GET', '/dev/build', ['skipannotation' => true]);
+        $this->extension->getOwner()->setRequest($request);
+
+        $this->assertFalse($this->extension->afterCallActionHandler());
+    }
+
+    public function testAfterCallActionHandlerConfigBlock()
+    {
+        DataObjectAnnotator::config()->set('enabled', false);
+
+        $this->assertFalse($this->extension->afterCallActionHandler());
+    }
+
+    public function testAfterCallActionHandlerDevBlock()
+    {
+        Environment::setEnv('SS_ENVIRONMENT_TYPE', 'Live');
+
+        $this->assertFalse($this->extension->afterCallActionHandler());
+    }
+
+    public function testAfterCallActionHandler()
+    {
+        $request = new HTTPRequest('GET', '/dev/build');
+        $this->extension->getOwner()->setRequest($request);
+        DataObjectAnnotator::config()->set('enabled', true);
+        DataObjectAnnotator::config()->set('enabled_modules', ['mysite']);
+        $this->assertTrue($this->extension->afterCallActionHandler());
+    }
+
+    public function testAfterCallActionHandlerRun()
+    {
+        $request = new HTTPRequest('GET', '/dev/build');
+        $this->extension->getOwner()->setRequest($request);
+        DataObjectAnnotator::config()->set('enabled', true);
+        DataObjectAnnotator::config()->set('enabled_modules', ['mysite']);
+
+        $this->extension->afterCallActionHandler();
+
+        $output = $this->getActualOutput();
+        $this->assertContains("GENERATING CLASS DOCBLOCKS", $output);
+        $this->assertContains("+ Page Annotated", $output);
+        $this->assertContains("DOCBLOCK GENERATION FINISHED!", $output);
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+        $this->extension = Injector::inst()->get(Annotatable::class);
+        $this->extension->setOwner(Controller::create());
     }
 }

--- a/tests/unit/AnnotateChangedDBSpecsTest.php
+++ b/tests/unit/AnnotateChangedDBSpecsTest.php
@@ -3,13 +3,13 @@
 namespace SilverLeague\IDEAnnotator\Tests;
 
 use PHPUnit_Framework_TestCase;
-use SilverLeague\IDEAnnotator\AnnotateClassInfo;
-use SilverLeague\IDEAnnotator\AnnotatePermissionChecker;
 use SilverLeague\IDEAnnotator\DataObjectAnnotator;
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Dev\SapphireTest;
+use SilverLeague\IDEAnnotator\Helpers\AnnotateClassInfo;
+use SilverLeague\IDEAnnotator\Helpers\AnnotatePermissionChecker;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
 
 /**
  * This test should fail, if a DB property is removed from
@@ -28,20 +28,6 @@ class AnnotateChangedDBSpecsTest extends SapphireTest
      * @var AnnotatePermissionChecker
      */
     protected $permissionChecker;
-
-    /**
-     * Setup Defaults
-     */
-    protected function setUp()
-    {
-        parent::setUp();
-        Config::modify()->set(Director::class, 'environment_type', 'dev');
-        Config::modify()->set(DataObjectAnnotator::class, 'enabled', true);
-        Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['ideannotator']);
-        Config::modify()->merge(TeamChanged::class, 'extensions', [Team_Extension::class]);
-
-        $this->annotator = Injector::inst()->get(MockDataObjectAnnotator::class);
-    }
 
     public function testChangedDBSpecifications()
     {
@@ -75,5 +61,19 @@ class AnnotateChangedDBSpecsTest extends SapphireTest
     public function tearDown()
     {
         parent::tearDown();
+    }
+
+    /**
+     * Setup Defaults
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        Config::modify()->set(Director::class, 'environment_type', 'dev');
+        Config::modify()->set(DataObjectAnnotator::class, 'enabled', true);
+        Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['ideannotator']);
+        Config::modify()->merge(TeamChanged::class, 'extensions', [Team_Extension::class]);
+
+        $this->annotator = Injector::inst()->get(MockDataObjectAnnotator::class);
     }
 }

--- a/tests/unit/AnnotateClassInfoTest.php
+++ b/tests/unit/AnnotateClassInfoTest.php
@@ -3,7 +3,7 @@
 namespace SilverLeague\IDEAnnotator\Tests;
 
 use PHPUnit_Framework_TestCase;
-use SilverLeague\IDEAnnotator\AnnotateClassInfo;
+use SilverLeague\IDEAnnotator\Helpers\AnnotateClassInfo;
 use SilverStripe\Dev\SapphireTest;
 
 /**

--- a/tests/unit/AnnotatePermissionCheckerTest.php
+++ b/tests/unit/AnnotatePermissionCheckerTest.php
@@ -2,14 +2,14 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
-use SilverStripe\Core\Injector\Injector;
-use SilverStripe\Core\Config\Config;
-use SilverStripe\Dev\SapphireTest;
 use SilverLeague\IDEAnnotator\DataObjectAnnotator;
+use SilverLeague\IDEAnnotator\Helpers\AnnotatePermissionChecker;
 use SilverStripe\Assets\File;
-use SilverStripe\ORM\DataObject;
-use SilverLeague\IDEAnnotator\AnnotatePermissionChecker;
 use SilverStripe\Control\Director;
+use SilverStripe\Core\Config\Config;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\SapphireTest;
+use SilverStripe\ORM\DataObject;
 
 /**
  * Class DataObjectAnnotatorTest
@@ -30,21 +30,8 @@ class AnnotatePermissionCheckerTest extends SapphireTest
     private $annotator;
 
     /**
-     * Setup Defaults
+     * Check if we're enabled
      */
-    protected function setUp()
-    {
-        parent::setUp();
-        Config::modify()->set(Director::class, 'environment_type', 'dev');
-        Config::modify()->set(DataObjectAnnotator::class, 'enabled', true);
-        Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['silverleague/ideannotator', 'mysite']);
-
-        Config::modify()->merge(Team::class, 'extensions', [Team_Extension::class]);
-
-        $this->annotator = Injector::inst()->get(MockDataObjectAnnotator::class);
-        $this->permissionChecker = Injector::inst()->get(AnnotatePermissionChecker::class);
-    }
-
     public function testIsEnabled()
     {
         $this->assertTrue($this->permissionChecker->isEnabled());
@@ -86,7 +73,7 @@ class AnnotatePermissionCheckerTest extends SapphireTest
         $this->assertFalse($this->permissionChecker->classNameIsAllowed(DataObject::class));
         $this->assertFalse($this->permissionChecker->classNameIsAllowed(File::class));
 
-        Config::inst()->remove(DataObjectAnnotator::class, 'enabled_modules');
+        Config::modify()->remove(DataObjectAnnotator::class, 'enabled_modules');
         Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['mysite']);
 
         $this->assertFalse($this->permissionChecker->classNameIsAllowed(Team::class));
@@ -95,5 +82,21 @@ class AnnotatePermissionCheckerTest extends SapphireTest
     public function tearDown()
     {
         parent::tearDown();
+    }
+
+    /**
+     * Setup Defaults
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        Config::modify()->set(Director::class, 'environment_type', 'dev');
+        Config::modify()->set(DataObjectAnnotator::class, 'enabled', true);
+        Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['silverleague/ideannotator', 'mysite']);
+
+        Config::modify()->merge(Team::class, 'extensions', [Team_Extension::class]);
+
+        $this->annotator = Injector::inst()->get(MockDataObjectAnnotator::class);
+        $this->permissionChecker = Injector::inst()->get(AnnotatePermissionChecker::class);
     }
 }

--- a/tests/unit/DataObjectAnnotatorTaskTest.php
+++ b/tests/unit/DataObjectAnnotatorTaskTest.php
@@ -3,7 +3,7 @@
 namespace SilverLeague\IDEAnnotator\Tests;
 
 use SilverLeague\IDEAnnotator\DataObjectAnnotator;
-use SilverLeague\IDEAnnotator\DataObjectAnnotatorTask;
+use SilverLeague\IDEAnnotator\Tasks\DataObjectAnnotatorTask;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Dev\SapphireTest;
@@ -13,9 +13,15 @@ class DataObjectAnnotatorTaskTest extends SapphireTest
     public function testConstruct()
     {
         $task = DataObjectAnnotatorTask::create();
-        $this->assertEquals('DataObject annotations for specific DataObjects, Extensions or Controllers', $task->getTitle());
-        $this->assertEquals("DataObject Annotator annotates your DO's if possible, helping you write better code.<br />"
-            . 'Usage: add the module or DataObject as parameter to the URL, e.g. ?module=mysite .', $task->getDescription());
+        $this->assertEquals(
+            'DataObject annotations for specific DataObjects, Extensions or Controllers',
+            $task->getTitle()
+        );
+        $this->assertEquals(
+            "DataObject Annotator annotates your DO's if possible, helping you write better code.<br />"
+            . 'Usage: add the module or DataObject as parameter to the URL, e.g. ?module=mysite .',
+            $task->getDescription()
+        );
     }
 
     public function testRunFalse()

--- a/tests/unit/DataObjectAnnotatorTaskTest.php
+++ b/tests/unit/DataObjectAnnotatorTaskTest.php
@@ -19,7 +19,7 @@ class DataObjectAnnotatorTaskTest extends SapphireTest
         );
         $this->assertEquals(
             "DataObject Annotator annotates your DO's if possible, helping you write better code.<br />"
-            . 'Usage: add the module or DataObject as parameter to the URL, e.g. ?module=mysite .',
+            . 'Usage: add the module or DataObject as parameter to the URL, e.g. ?module=mysite',
             $task->getDescription()
         );
     }

--- a/tests/unit/DataObjectAnnotatorTest.php
+++ b/tests/unit/DataObjectAnnotatorTest.php
@@ -2,13 +2,14 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
+use Page;
 use PageController;
 use PHPUnit_Framework_TestCase;
 use RootTeam;
-use SilverLeague\IDEAnnotator\Annotatable;
-use SilverLeague\IDEAnnotator\AnnotateClassInfo;
-use SilverLeague\IDEAnnotator\AnnotatePermissionChecker;
 use SilverLeague\IDEAnnotator\DataObjectAnnotator;
+use SilverLeague\IDEAnnotator\Extensions\Annotatable;
+use SilverLeague\IDEAnnotator\Helpers\AnnotateClassInfo;
+use SilverLeague\IDEAnnotator\Helpers\AnnotatePermissionChecker;
 use SilverStripe\Control\Director;
 use SilverStripe\Core\Config\Config;
 use SilverStripe\Core\Injector\Injector;
@@ -36,18 +37,8 @@ class DataObjectAnnotatorTest extends SapphireTest
     private $permissionChecker;
 
     /**
-     * Setup Defaults
+     * Are we enabled?
      */
-    protected function setUp()
-    {
-        parent::setUp();
-        Config::modify()->set(DataObjectAnnotator::class, 'enabled', true);
-        Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['silverleague/ideannotator']);
-
-        $this->annotator = Injector::inst()->get(MockDataObjectAnnotator::class);
-        $this->permissionChecker = Injector::inst()->get(AnnotatePermissionChecker::class);
-    }
-
     public function testIsEnabled()
     {
         $this->assertTrue(DataObjectAnnotator::isEnabled());
@@ -59,23 +50,22 @@ class DataObjectAnnotatorTest extends SapphireTest
     public function testGetClassesForModule()
     {
         $expectedClasses = [
-            Team::class                             => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_Team.php',
-            TeamChanged::class                      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_TeamChanged.php',
-            TeamComment::class                      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_TeamComment.php',
-            DocBlockMockWithDocBlock::class         => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DocBlockMockWithDocBlock.php',
-            OtherDocBlockMockWithDocBlock::class    => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DocBlockMockWithDocBlock.php',
-            DataObjectWithOldStyleTagMarkers::class => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DocBlockMockWithDocBlock.php',
-            DoubleDataObjectInOneFile1::class       => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DoubleDataObjectInOneFile.php',
-            DoubleDataObjectInOneFile2::class       => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DoubleDataObjectInOneFile.php',
-            SubTeam::class                          => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_SubTeam.php',
-            Player::class                           => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_Player.php',
-            Team_Extension::class                   => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_Team_Extension.php',
-            Annotatable::class                      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Extensions' . DIRECTORY_SEPARATOR . 'Annotatable.php',
-            AnnotatorPageTest_Extension::class      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'AnnotatorPageTest.php',
-            RootTeam::class                         => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'RootTeam.php',
-            AnnotatorPageTest::class                => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'AnnotatorPageTest.php',
-            AnnotatorPageTestController::class      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'AnnotatorPageTest.php',
-            TeamSupporter::class                    => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_TeamSupporter.php',
+            Team::class                          => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_Team.php',
+            TeamChanged::class                   => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_TeamChanged.php',
+            TeamComment::class                   => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_TeamComment.php',
+            DocBlockMockWithDocBlock::class      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DocBlockMockWithDocBlock.php',
+            OtherDocBlockMockWithDocBlock::class => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DocBlockMockWithDocBlock.php',
+            DoubleDataObjectInOneFile1::class    => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DoubleDataObjectInOneFile.php',
+            DoubleDataObjectInOneFile2::class    => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DoubleDataObjectInOneFile.php',
+            SubTeam::class                       => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_SubTeam.php',
+            Player::class                        => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_Player.php',
+            Team_Extension::class                => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_Team_Extension.php',
+            Annotatable::class                   => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR . 'Extensions' . DIRECTORY_SEPARATOR . 'Annotatable.php',
+            AnnotatorPageTest_Extension::class   => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'AnnotatorPageTest.php',
+            RootTeam::class                      => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'RootTeam.php',
+            AnnotatorPageTest::class             => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'AnnotatorPageTest.php',
+            AnnotatorPageTestController::class   => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'AnnotatorPageTest.php',
+            TeamSupporter::class                 => Director::baseFolder() . DIRECTORY_SEPARATOR . 'ideannotator' . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'mock' . DIRECTORY_SEPARATOR . 'DataObjectAnnotatorTest_TeamSupporter.php',
         ];
         $classes = $this->annotator->getClassesForModule('silverleague/ideannotator');
         // Sort the array, so we don't get accidental errors due to manual ordering
@@ -83,7 +73,6 @@ class DataObjectAnnotatorTest extends SapphireTest
         ksort($classes);
         $this->assertEquals($expectedClasses, $classes);
     }
-
 
     /**
      * As below, as we don't want to actively change the mocks, so enable mysite
@@ -131,6 +120,8 @@ class DataObjectAnnotatorTest extends SapphireTest
         $this->assertContains('@property string $Title', $content);
         $this->assertContains('@property int $VisitCount', $content);
         $this->assertContains('@property float $Price', $content);
+        $this->assertContains('@property string $Dude', $content);
+        $this->assertContains('@property string $Dudette', $content);
 
         // has_one ID
         $this->assertContains('@property int $CaptainID', $content);
@@ -159,6 +150,52 @@ class DataObjectAnnotatorTest extends SapphireTest
         $this->assertContains('@mixin \SilverLeague\IDEAnnotator\Tests\Team_Extension', $content);
     }
 
+    /**
+     * Test if the correct annotations are generated
+     * for all database fields, relations and extensions
+     * and that the start and end tags are present
+     */
+    public function testShortFileContentWithAnnotations()
+    {
+        Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', true);
+
+        $classInfo = new AnnotateClassInfo(Team::class);
+        $filePath = $classInfo->getClassFilePath();
+
+        $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Team::class);
+
+        // database fields
+        $this->assertContains('@property string $Title', $content);
+        $this->assertContains('@property int $VisitCount', $content);
+        $this->assertContains('@property float $Price', $content);
+
+        // has_one ID
+        $this->assertContains('@property int $CaptainID', $content);
+        // has_one relation
+        $this->assertContains('@method Player Captain()', $content);
+        // has_many relation
+        $this->assertContains(
+            '@method DataList|SubTeam[] SubTeams()',
+            $content
+        );
+        // many_many relation
+        $this->assertContains(
+            '@method ManyManyList|Player[] Players()',
+            $content
+        );
+        $this->assertContains(
+            '@method ManyManyList|Player[] Reserves()',
+            $content
+        );
+        $this->assertContains(
+            '@method DataList|TeamSupporter[] Supporters()',
+            $content
+        );
+
+        // DataExtension
+        $this->assertContains('@mixin Team_Extension', $content);
+    }
+
     public function testInversePlayerRelationOfTeam()
     {
         $classInfo = new AnnotateClassInfo(Player::class);
@@ -168,7 +205,9 @@ class DataObjectAnnotatorTest extends SapphireTest
 
         $this->assertContains('@property boolean $IsRetired', $content);
         $this->assertContains('@property string $ShirtNumber', $content);
+        $this->assertContains('@property string $Shirt', $content);
         $this->assertContains('@property int $FavouriteTeamID', $content);
+        $this->assertContains('@method \SilverLeague\IDEAnnotator\Tests\Team CaptainTeam()', $content);
         $this->assertContains('@method \SilverLeague\IDEAnnotator\Tests\Team FavouriteTeam()', $content);
 
         $this->assertContains(
@@ -181,6 +220,78 @@ class DataObjectAnnotatorTest extends SapphireTest
         );
     }
 
+    public function testDefaults()
+    {
+        $count = 0;
+        DataObjectAnnotator::pushExtensionClass(Page::class);
+        foreach (DataObjectAnnotator::getExtensionClasses() as $class) {
+            if ($class === 'Page') {
+                $count++;
+            }
+        }
+        $this->assertEquals(1, $count);
+    }
+
+    public function testSetExtensionClasses()
+    {
+        $classes = DataObjectAnnotator::getExtensionClasses();
+        $expected = [
+            'SilverLeague\IDEAnnotator\Tests\AnnotatorPageTestController',
+            'SilverLeague\IDEAnnotator\Tests\Team',
+            'SilverStripe\Admin\LeftAndMain',
+            'SilverStripe\Admin\ModalController',
+            'SilverStripe\Assets\File',
+            'SilverStripe\AssetAdmin\Forms\FileFormFactory',
+            'SilverStripe\Assets\Shortcodes\FileShortcodeProvider',
+            'SilverStripe\CMS\Controllers\ContentController',
+            'SilverStripe\CMS\Controllers\ModelAsController',
+            'SilverStripe\CMS\Model\SiteTree',
+            'SilverStripe\Control\Controller',
+            'SilverStripe\Dev\DevBuildController',
+            'SilverStripe\Forms\Form',
+            'SilverStripe\ORM\DataObject',
+            'SilverStripe\Security\Group',
+            'SilverStripe\Security\Member',
+            'SilverStripe\Forms\GridField\GridFieldConfig_Base',
+            'SilverStripe\Forms\GridField\GridFieldConfig_RecordEditor',
+            'SilverStripe\Forms\GridField\GridFieldConfig_RelationEditor',
+            'SilverStripe\Forms\GridField\GridFieldDetailForm',
+            'SilverStripe\Forms\GridField\GridFieldPrintButton',
+            'SilverStripe\ORM\FieldType\DBField',
+            'SilverStripe\GraphQL\Scaffolding\Scaffolders\DataObjectScaffolder',
+            'SilverStripe\GraphQL\Scaffolding\Scaffolders\SchemaScaffolder',
+            'SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\Read',
+            'SilverStripe\GraphQL\Scaffolding\Scaffolders\CRUD\ReadOne',
+        ];
+        DataObjectAnnotator::setExtensionClasses($classes);
+
+        $this->assertEquals($expected, DataObjectAnnotator::getExtensionClasses());
+    }
+
+    public function testShortInversePlayerRelationOfTeam()
+    {
+        Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', true);
+
+        $classInfo = new AnnotateClassInfo(Player::class);
+        $filePath = $classInfo->getClassFilePath();
+
+        $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Player::class);
+
+        $this->assertContains('@property boolean $IsRetired', $content);
+        $this->assertContains('@property string $ShirtNumber', $content);
+        $this->assertContains('@property int $FavouriteTeamID', $content);
+        $this->assertContains('@method Team FavouriteTeam()', $content);
+
+        $this->assertContains(
+            '@method ManyManyList|Team[] TeamPlayer()',
+            $content
+        );
+        $this->assertContains(
+            '@method ManyManyList|Team[] TeamReserve()',
+            $content
+        );
+    }
+
     public function testExistingMethodsWillNotBeTagged()
     {
         $classInfo = new AnnotateClassInfo(Team::class);
@@ -189,6 +300,20 @@ class DataObjectAnnotatorTest extends SapphireTest
         $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Team::class);
         $this->assertNotContains(
             '@method \SilverStripe\ORM\ManyManyList|\SilverLeague\IDEAnnotator\Tests\SubTeam[] SecondarySubTeams()',
+            $content
+        );
+    }
+
+    public function testShortExistingMethodsWillNotBeTagged()
+    {
+        Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', true);
+
+        $classInfo = new AnnotateClassInfo(Team::class);
+        $filePath = $classInfo->getClassFilePath();
+
+        $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Team::class);
+        $this->assertNotContains(
+            '@method ManyManyList|SubTeam[] SecondarySubTeams()',
             $content
         );
     }
@@ -241,6 +366,31 @@ class DataObjectAnnotatorTest extends SapphireTest
     }
 
     /**
+     * Test the generation of annotations for a DataExtension
+     */
+    public function testShortAnnotateDataExtension()
+    {
+        Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', true);
+
+        $classInfo = new AnnotateClassInfo(Team_Extension::class);
+        $filePath = $classInfo->getClassFilePath();
+        $original = file_get_contents($filePath);
+        $annotated = $this->annotator->getGeneratedFileContent($original, Team_Extension::class);
+
+        $this->assertContains(
+            '@property Team|Team_Extension $owner',
+            $annotated
+        );
+        $this->assertContains('@property string $ExtendedVarcharField', $annotated);
+        $this->assertContains('@property int $ExtendedIntField', $annotated);
+        $this->assertContains('@property int $ExtendedHasOneRelationshipID', $annotated);
+        $this->assertContains(
+            '@method Player ExtendedHasOneRelationship()',
+            $annotated
+        );
+    }
+
+    /**
      *
      */
     public function testTwoClassesInOneFile()
@@ -260,5 +410,20 @@ class DataObjectAnnotatorTest extends SapphireTest
     public function tearDown()
     {
         parent::tearDown();
+    }
+
+    /**
+     * Setup Defaults
+     */
+    protected function setUp()
+    {
+        parent::setUp();
+        Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', false);
+
+        Config::modify()->set(DataObjectAnnotator::class, 'enabled', true);
+        Config::modify()->set(DataObjectAnnotator::class, 'enabled_modules', ['silverleague/ideannotator']);
+
+        $this->annotator = Injector::inst()->get(MockDataObjectAnnotator::class);
+        $this->permissionChecker = Injector::inst()->get(AnnotatePermissionChecker::class);
     }
 }


### PR DESCRIPTION
Adding support for short classnames and updating the docs accordingly.
This works via a config, that gets the short classname to prevent IDE's from mentioning "Unnecessary FQN"

Included is a fix for a whitespace trim introduced in rc-1
Resolves #108 , SQN instead of FQN