### PR TITLE
handle abstract owner

### DIFF
--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -181,6 +181,11 @@ abstract class AbstractTagGenerator
     protected function generateOwnerTags()
     {
         $className = $this->className;
+        // If className is abstract, Injector will fail to instantiate it
+        $reflection = new \ReflectionClass($className);
+        if ($reflection->isAbstract()) {
+            return;
+        }
         if (Injector::inst()->get($this->className) instanceof Extension) {
             $owners = array_filter(DataObjectAnnotator::getExtensionClasses(), function ($class) use ($className) {
                 $config = Config::inst()->get($class, 'extensions');


### PR DESCRIPTION
In my case (an abstract ModelAdmin class), the current code will fail. Checking if ClassName is abstract allows the ideannotator to work properly.