### PR TITLE
Change Requirements to silverstripe/framework rather than silverstripe/cms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 sudo: false
 
 language: php
@@ -5,9 +7,7 @@ language: php
 matrix:
   include:
     - php: 5.6
-      env: DB=MYSQL RECIPE_VERSION="1.0.x-dev" PHPUNIT_TEST=1
-    - php: 7.0
-      env: DB=MYSQL RECIPE_VERSION="1.1.x-dev" PHPCS_TEST=1 PHPUNIT_COVERAGE_TEST=1
+      env: DB=PGSQL RECIPE_VERSION="4.2.x-dev" PHPUNIT_TEST=1
     - php: 7.1
       env: DB=PGSQL RECIPE_VERSION="4.2.x-dev" PHPUNIT_TEST=1
     - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "silverstripe/cms": "^4",
+        "silverstripe/framework": "^4",
         "phpdocumentor/reflection-docblock": "^2.0@dev"
     },
     "require-dev": {


### PR DESCRIPTION
This pull request changes the requirement of silverstripe/cms to silverstripe/framework I don't see a reason for this to be locked to requiring the cms opening up to just requiring the framework allows for non-cms projects to use this.