### PR TITLE
remove text in Class phpdoc saying this is a class

### DIFF
--- a/src/Generators/DocBlockGenerator.php
+++ b/src/Generators/DocBlockGenerator.php
@@ -99,10 +99,6 @@ class DocBlockGenerator
     {
         $docBlock = new DocBlock($this->removeExistingSupportedTags($existingDocBlock));
 
-        if (!$docBlock->getText()) {
-            $docBlock->setText('Class \\' . $this->className);
-        }
-
         foreach ($this->getGeneratedTags() as $tag) {
             $docBlock->appendTag($tag);
         }

--- a/tests/unit/ControllerAnnotatorTest.php
+++ b/tests/unit/ControllerAnnotatorTest.php
@@ -39,7 +39,6 @@ class ControllerAnnotatorTest extends SapphireTest
 
         $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), TestAnnotatorPage::class);
 
-        $this->assertContains(' * Class \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPage', $content);
         $this->assertContains('@property string $SubTitle', $content);
     }
 
@@ -53,7 +52,6 @@ class ControllerAnnotatorTest extends SapphireTest
             TestAnnotatorPageController::class
         );
 
-        $this->assertContains(' * Class \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPageController', $content);
         $this->assertContains('@property \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPage dataRecord', $content);
         $this->assertContains('@method \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPage data()', $content);
         $this->assertContains('@mixin \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPage', $content);
@@ -70,7 +68,6 @@ class ControllerAnnotatorTest extends SapphireTest
         $original = file_get_contents($filePath);
         $annotated = $this->annotator->getGeneratedFileContent($original, TestAnnotatorPage_Extension::class);
 
-        $this->assertContains(' * Class \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPage_Extension', $annotated);
         $this->assertContains(
             '@property \SilverLeague\IDEAnnotator\Tests\TestAnnotatorPageController|\SilverLeague\IDEAnnotator\Tests\TestAnnotatorPage_Extension $owner',
             $annotated

--- a/tests/unit/DataObjectAnnotatorTest.php
+++ b/tests/unit/DataObjectAnnotatorTest.php
@@ -114,9 +114,6 @@ class DataObjectAnnotatorTest extends SapphireTest
 
         $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Team::class);
 
-        // ClassName title
-        $this->assertContains(' * Class \SilverLeague\IDEAnnotator\Tests\Team', $content);
-
         // database fields
         $this->assertContains('@property string $Title', $content);
         $this->assertContains('@property int $VisitCount', $content);


### PR DESCRIPTION
 - it is not a phpdoc so it does not helping IDE anyhow
 - unnecessary cognitive load for developer
 - unnecessary changes(mess) in git