### PR TITLE
BUG Prevent extensions from decorating $owner property with redundant subclasses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,15 +7,15 @@ language: php
 matrix:
   include:
     - php: 5.6
-      env: DB=PGSQL RECIPE_VERSION="4.2.x-dev" PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION="^4.2" PHPUNIT_TEST=1
     - php: 7.1
-      env: DB=PGSQL RECIPE_VERSION="4.2.x-dev" PHPUNIT_TEST=1
+      env: DB=PGSQL RECIPE_VERSION="^4.2" PHPUNIT_TEST=1
     - php: 7.2
-      env: DB=MYSQL RECIPE_VERSION="4.3.x-dev" PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION="^4.3" PHPUNIT_TEST=1
     - php: 7.3
-      env: DB=MYSQL RECIPE_VERSION="4.4.x-dev" PHPUNIT_TEST=1 PHPCS_TEST=1
+      env: DB=MYSQL RECIPE_VERSION="^4.4" PHPUNIT_TEST=1 PHPCS_TEST=1
     - php: 7.3
-      env: DB=MYSQL RECIPE_VERSION="4.x-dev" PHPUNIT_TEST=1
+      env: DB=MYSQL RECIPE_VERSION="^4" PHPUNIT_TEST=1
 
 before_script:
   - phpenv rehash
@@ -24,7 +24,7 @@ before_script:
   - composer validate
   - if [[ $DB == PGSQL ]]; then composer require --prefer-dist --no-update silverstripe/postgresql 2.1.x-dev; fi
   - composer require --no-update silverstripe/recipe-cms "$RECIPE_VERSION"
-  - composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - composer install --prefer-source --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
 
 script:
   - if [[ $PHPUNIT_TEST ]]; then vendor/bin/phpunit; fi

--- a/src/Extensions/Annotatable.php
+++ b/src/Extensions/Annotatable.php
@@ -56,7 +56,7 @@ class Annotatable extends Extension
      * @throws NotFoundExceptionInterface
      * @throws ReflectionException
      */
-    public function annotateModules(): bool
+    public function annotateModules()
     {
         $envIsAllowed = Director::isDev() && DataObjectAnnotator::config()->get('enabled');
         $skipAnnotation = $this->owner->getRequest()->getVar('skipannotation');

--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -208,7 +208,7 @@ abstract class AbstractTagGenerator
      * @param string $extensionClass Class name of the extension
      * @return string[]|Generator List of all direct owners of this extension
      */
-    protected function getOwnerClasses(string $extensionClass)
+    protected function getOwnerClasses($extensionClass)
     {
         foreach (DataObjectAnnotator::getExtensionClasses() as $objectClass) {
             $config = Config::inst()->get(

--- a/tests/unit/DataObjectAnnotatorTest.php
+++ b/tests/unit/DataObjectAnnotatorTest.php
@@ -356,7 +356,7 @@ class DataObjectAnnotatorTest extends SapphireTest
         $annotated = $this->annotator->getGeneratedFileContent($original, Team_Extension::class);
 
         $this->assertContains(
-            '@property \SilverLeague\IDEAnnotator\Tests\SubTeam|\SilverLeague\IDEAnnotator\Tests\Team|\SilverLeague\IDEAnnotator\Tests\Team_Extension $owner',
+            '@property \SilverLeague\IDEAnnotator\Tests\Team|\SilverLeague\IDEAnnotator\Tests\Team_Extension $owner',
             $annotated
         );
         $this->assertContains('@property string $ExtendedVarcharField', $annotated);
@@ -381,7 +381,7 @@ class DataObjectAnnotatorTest extends SapphireTest
         $annotated = $this->annotator->getGeneratedFileContent($original, Team_Extension::class);
 
         $this->assertContains(
-            '@property SubTeam|Team|Team_Extension $owner',
+            '@property Team|Team_Extension $owner',
             $annotated
         );
         $this->assertContains('@property string $ExtendedVarcharField', $annotated);


### PR DESCRIPTION
If Page has an extension HeaderExtension, then the HeaderExtension.php does not need to include ALL of the Page subclasess in the $owner property; The base class is enough. :)