### PR TITLE
Move to a modern version of reflection docblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,4 +86,6 @@ For further documentation information, see the [docs](docs/en/Index.md)
 This module changes the content of your files and currently there is no backup functionality. PHPStorm has a Local history for files and of course you have your code version controlled...
 I tried to add complete UnitTests, but I can't garantuee every situation is covered.
 
+Windows users should be aware that the PHP Docs are generated with PSR in mind and use \n for line endings rather than Window's \r\n, some editors may have a hard time with these line endings.
+
 This module should **never** be installed on a production environment.

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^7.2 || ^8.0",
         "silverstripe/framework": "^4",
-        "phpdocumentor/reflection-docblock": "^2.0@dev"
+        "phpdocumentor/reflection-docblock": "^5.2"
     },
     "require-dev": {
         "scriptfusion/phpunit-immediate-exception-printer": "^1",

--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -113,7 +113,7 @@ abstract class AbstractTagGenerator
      */
     public function getTags()
     {
-        return (array)call_user_func_array('array_merge', $this->tags);
+        return (array)call_user_func_array('array_merge', array_values($this->tags));
     }
 
     /**

--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -16,6 +16,7 @@ use SilverStripe\Core\Injector\Injector;
 use Generator;
 use ReflectionClass;
 use ReflectionException;
+use SilverLeague\IDEAnnotator\Reflection\ShortNameResolver;
 
 /**
  * AbstractTagGenerator
@@ -70,7 +71,12 @@ abstract class AbstractTagGenerator
         $this->tags = $this->getSupportedTagTypes();
 
         //Init the tag factory
-        $fqsenResolver = new FqsenResolver();
+        if (DataObjectAnnotator::config()->get('use_short_name')) {
+            $fqsenResolver = new ShortNameResolver();
+        } else {
+            $fqsenResolver = new FqsenResolver();
+        }
+
         $this->tagFactory = new StandardTagFactory($fqsenResolver);
         $descriptionFactory = new DescriptionFactory($this->tagFactory);
         $this->tagFactory->addService($descriptionFactory);

--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -53,6 +53,8 @@ abstract class AbstractTagGenerator
      */
     protected $tagFactory;
 
+    protected static $pageClassesCache = [];
+
     /**
      * DocBlockTagGenerator constructor.
      *
@@ -160,7 +162,7 @@ abstract class AbstractTagGenerator
      */
     protected function pushTagWithExistingComment($type, $tagString)
     {
-        $tagString = '@' . $type . ' ' . $tagString;
+        $tagString = sprintf('@%s %s', $type, $tagString);
         $tagString .= $this->getExistingTagCommentByTagString($tagString);
 
         return $this->tagFactory->create($tagString);
@@ -209,7 +211,7 @@ abstract class AbstractTagGenerator
         if (Injector::inst()->get($this->className) instanceof Extension) {
             $owners = iterator_to_array($this->getOwnerClasses($className));
             $owners[] = $this->className;
-            $tagString = '\\' . implode("|\\", array_values($owners)) . ' $owner';
+            $tagString = sprintf('\\%s $owner', implode("|\\", array_values($owners)));
             if (DataObjectAnnotator::config()->get('use_short_name')) {
                 foreach ($owners as $key => $owner) {
                     $owners[$key] = $this->getAnnotationClassName($owner);

--- a/src/Generators/ControllerTagGenerator.php
+++ b/src/Generators/ControllerTagGenerator.php
@@ -11,8 +11,6 @@ use SilverStripe\Core\Config\Config;
 
 class ControllerTagGenerator extends AbstractTagGenerator
 {
-    private static $pageClassesCache = [];
-
     /**
      * @return void
      * @throws ReflectionException
@@ -35,8 +33,8 @@ class ControllerTagGenerator extends AbstractTagGenerator
         if (class_exists($pageClassname) && $this->isContentController($this->className)) {
             $pageClassname = $this->getAnnotationClassName($pageClassname);
 
-            $this->pushPropertyTag($pageClassname . ' dataRecord');
-            $this->pushMethodTag('data()', $pageClassname . ' data()');
+            $this->pushPropertyTag(sprintf('%s dataRecord', $pageClassname));
+            $this->pushMethodTag('data()', sprintf('%s data()', $pageClassname));
 
             // don't mixin Page, since this is a ContentController method
             if ($pageClassname !== 'Page') {
@@ -51,8 +49,8 @@ class ControllerTagGenerator extends AbstractTagGenerator
                 if (Config::inst()->get($pageClassname, 'controller_name') == $this->className) {
                     $pageClassname = $this->getAnnotationClassName($pageClassname);
 
-                    $this->pushPropertyTag($pageClassname . ' dataRecord');
-                    $this->pushMethodTag('data()', $pageClassname . ' data()');
+                    $this->pushPropertyTag(sprintf('%s dataRecord', $pageClassname));
+                    $this->pushMethodTag('data()', sprintf('%s data()', $pageClassname));
 
                     // don't mixin Page, since this is a ContentController method
                     if ($pageClassname !== 'Page') {

--- a/src/Generators/DocBlockGenerator.php
+++ b/src/Generators/DocBlockGenerator.php
@@ -66,6 +66,10 @@ class DocBlockGenerator
     public function getExistingTags()
     {
         $docBlock = $this->getExistingDocBlock();
+        if (!$docBlock) {
+            return [];
+        }
+        
         $docBlock = $this->docBlockFactory->create($docBlock);
 
         return $docBlock->getTags();
@@ -104,7 +108,7 @@ class DocBlockGenerator
      */
     protected function mergeGeneratedTagsIntoDocBlock($existingDocBlock)
     {
-        $docBlock = $this->docBlockFactory->create($existingDocBlock);
+        $docBlock = $this->docBlockFactory->create(($existingDocBlock ?: "/**\n*/"));
 
         $summary = $docBlock->getSummary();
         if (!$summary) {

--- a/src/Generators/DocBlockGenerator.php
+++ b/src/Generators/DocBlockGenerator.php
@@ -69,7 +69,7 @@ class DocBlockGenerator
         if (!$docBlock) {
             return [];
         }
-        
+
         $docBlock = $this->docBlockFactory->create($docBlock);
 
         return $docBlock->getTags();
@@ -112,7 +112,7 @@ class DocBlockGenerator
 
         $summary = $docBlock->getSummary();
         if (!$summary) {
-            $summary = 'Class \\' . $this->className;
+            $summary = sprintf('Class \\%s', $this->className);
         }
 
         $docBlock = new DocBlock($summary, $docBlock->getDescription(), $this->getGeneratedTags());

--- a/src/Generators/OrmTagGenerator.php
+++ b/src/Generators/OrmTagGenerator.php
@@ -44,7 +44,7 @@ class OrmTagGenerator extends AbstractTagGenerator
      */
     protected static $dbfield_tagnames = [
         DBInt::class     => 'int',
-        DBBoolean::class => 'boolean',
+        DBBoolean::class => 'bool',
         DBFloat::class   => 'float',
         DBDecimal::class => 'float',
     ];

--- a/src/Helpers/AnnotatePermissionChecker.php
+++ b/src/Helpers/AnnotatePermissionChecker.php
@@ -120,7 +120,7 @@ class AnnotatePermissionChecker
      */
     public function moduleIsAllowed($moduleName)
     {
-        return in_array($moduleName, $this->enabledModules(), null);
+        return in_array($moduleName, $this->enabledModules(), false);
     }
 
     /**

--- a/src/Reflection/ShortNameResolver.php
+++ b/src/Reflection/ShortNameResolver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SilverLeague\IDEAnnotator\Reflection;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\FqsenResolver;
+use phpDocumentor\Reflection\Types\Context;
+
+class ShortNameResolver extends FqsenResolver
+{
+    public function resolve(string $fqsen, ?Context $context = null): Fqsen
+    {
+        if ($context === null) {
+            $context = new Context('');
+        }
+
+        return new Fqsen($fqsen);
+    }
+}

--- a/tests/unit/DataObjectAnnotatorTest.php
+++ b/tests/unit/DataObjectAnnotatorTest.php
@@ -204,7 +204,7 @@ class DataObjectAnnotatorTest extends SapphireTest
 
         $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Player::class);
 
-        $this->assertContains('@property boolean $IsRetired', $content);
+        $this->assertContains('@property bool $IsRetired', $content);
         $this->assertContains('@property string $ShirtNumber', $content);
         $this->assertContains('@property string $Shirt', $content);
         $this->assertContains('@property int $FavouriteTeamID', $content);
@@ -277,7 +277,7 @@ class DataObjectAnnotatorTest extends SapphireTest
 
         $content = $this->annotator->getGeneratedFileContent(file_get_contents($filePath), Player::class);
 
-        $this->assertContains('@property boolean $IsRetired', $content);
+        $this->assertContains('@property bool $IsRetired', $content);
         $this->assertContains('@property string $ShirtNumber', $content);
         $this->assertContains('@property int $FavouriteTeamID', $content);
         $this->assertContains('@method Team FavouriteTeam()', $content);


### PR DESCRIPTION
This pull request incorporates changes from #139 but more importantly switches to phpdocumentor/reflection-docblock ^5.2 to address compatibility with PHPUnit ^9.5 that Silverstripe 4.10 supports. I believe this may also break compatibility with Silverstripe projects using PHPUnit 5.7 because of conflicting dependencies between the two versions.