### PR TITLE
Fixed PHP8 incompatibility (array_merge() does not accept unknown nam…

### DIFF
--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -88,7 +88,7 @@ abstract class AbstractTagGenerator
      */
     public function getTags()
     {
-        return (array)call_user_func_array('array_merge', $this->tags);
+        return (array)call_user_func_array('array_merge', array_values($this->tags));
     }
 
     /**


### PR DESCRIPTION
Running ideaannotator on PHP8 leads to an error on dev/build:
array_merge() does not accept unknown named parameters

This fixes it.