### PR TITLE
Fix when the namespace contains 'Controller'

### DIFF
--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -214,7 +214,7 @@ abstract class AbstractTagGenerator
         if ($reflection->isAbstract()) {
             return;
         }
-        if (Injector::inst()->get($this->className) instanceof Extension) {
+        if ($reflection instanceof Extension) {
             $owners = iterator_to_array($this->getOwnerClasses($className));
             $owners[] = $this->className;
             $tagString = sprintf('\\%s $owner', implode("|\\", array_values($owners)));

--- a/src/Generators/ControllerTagGenerator.php
+++ b/src/Generators/ControllerTagGenerator.php
@@ -42,7 +42,12 @@ class ControllerTagGenerator extends AbstractTagGenerator
      */
     protected function generateControllerObjectTags()
     {
-        $pageClassname = str_replace(['_Controller', 'Controller'], '', $this->className);
+        $shortName = ClassInfo::shortName($this->className);
+        // Strip "Controller" or "_Controller" from the class short name
+        $shortSansController = str_replace(['_Controller', 'Controller'], '', $shortName);
+        // And push it back in :)
+        $pageClassname = str_replace($shortName, $shortSansController, $this->className);
+
         if (class_exists($pageClassname) && $this->isContentController($this->className)) {
             $pageClassname = $this->getAnnotationClassName($pageClassname);
 


### PR DESCRIPTION
Check the reflection instance type instead of instantiating the class. Instantiating throws errors for __construct with arguments