### PR TITLE
Change requirements to include SS5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         }
     ],
     "require": {
-        "php": "^7.2 || ^8.0",
-        "silverstripe/framework": "^4",
+        "php": "^8.0",
+        "silverstripe/framework": "^4 || ^5",
         "phpdocumentor/reflection-docblock": "^5.2"
     },
     "require-dev": {


### PR DESCRIPTION
Module is directly compatible with SS5 beta1, so for now, only a composer.json update is necessary.