### PR TITLE
Check if extension without instantiation (elemental compatibility)

### DIFF
--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -215,7 +215,7 @@ abstract class AbstractTagGenerator
         if ($reflection->isAbstract()) {
             return;
         }
-        if (Injector::inst()->get($this->className) instanceof Extension) {
+        if (is_a($this->className, Extension::class, true)) {
             $owners = iterator_to_array($this->getOwnerClasses($className));
             $owners[] = $this->className;
             $tagString = sprintf('\\%s $owner', implode("|\\", array_values($owners)));

--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -215,7 +215,7 @@ abstract class AbstractTagGenerator
         if ($reflection->isAbstract()) {
             return;
         }
-        if (is_a($this->className, Extension::class, true)) {
+        if ($reflection->isSubclassOf(Extension::class)) {
             $owners = iterator_to_array($this->getOwnerClasses($className));
             $owners[] = $this->className;
             $tagString = sprintf('\\%s $owner', implode("|\\", array_values($owners)));


### PR DESCRIPTION
Credit to Guy Sartorelli for help on this. Instantiation without args here was causing docblock generation to fail for subclasses of elementcontroller using elemental.