### PR TITLE
Fix return types in unit tests

### DIFF
--- a/tests/unit/AnnotatableTest.php
+++ b/tests/unit/AnnotatableTest.php
@@ -90,7 +90,7 @@ class AnnotatableTest extends SapphireTest
         $this->assertContains("DOCBLOCK GENERATION FINISHED!", $output);
     }
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         $this->extension = Injector::inst()->get(Annotatable::class);

--- a/tests/unit/AnnotateChangedDBSpecsTest.php
+++ b/tests/unit/AnnotateChangedDBSpecsTest.php
@@ -58,7 +58,7 @@ class AnnotateChangedDBSpecsTest extends SapphireTest
         $this->assertContains('This is the Boss', $content);
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }
@@ -66,7 +66,7 @@ class AnnotateChangedDBSpecsTest extends SapphireTest
     /**
      * Setup Defaults
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Config::modify()->set(Director::class, 'environment_type', 'dev');

--- a/tests/unit/AnnotateClassInfoTest.php
+++ b/tests/unit/AnnotateClassInfoTest.php
@@ -19,7 +19,7 @@ class AnnotateClassInfoTest extends SapphireTest
         $this->assertEquals('silverleague/ideannotator', $classInfo->getModuleName());
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }

--- a/tests/unit/AnnotatePermissionCheckerTest.php
+++ b/tests/unit/AnnotatePermissionCheckerTest.php
@@ -80,7 +80,7 @@ class AnnotatePermissionCheckerTest extends SapphireTest
         $this->assertFalse($this->permissionChecker->classNameIsAllowed(Team::class));
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }
@@ -88,7 +88,7 @@ class AnnotatePermissionCheckerTest extends SapphireTest
     /**
      * Setup Defaults
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Config::modify()->set(Director::class, 'environment_type', 'dev');

--- a/tests/unit/ControllerAnnotatorTest.php
+++ b/tests/unit/ControllerAnnotatorTest.php
@@ -122,7 +122,7 @@ class ControllerAnnotatorTest extends SapphireTest
         );
     }
 
-    public function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
     }
@@ -130,7 +130,7 @@ class ControllerAnnotatorTest extends SapphireTest
     /**
      * Setup Defaults
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', false);

--- a/tests/unit/DataObjectAnnotatorTest.php
+++ b/tests/unit/DataObjectAnnotatorTest.php
@@ -413,7 +413,7 @@ class DataObjectAnnotatorTest extends SapphireTest
     /**
      * Setup Defaults
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
         Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', false);


### PR DESCRIPTION
This was preventing my own tests so here it is

Fixes: https://github.com/silverleague/silverstripe-ideannotator/issues/152