### PR TITLE
Fixed regression where use_short_name would be prefixed with a backslash

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.0",
         "silverstripe/framework": "^4 || ^5",
-        "phpdocumentor/reflection-docblock": "^5"
+        "phpdocumentor/reflection-docblock": "^5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
This pull fixes the issue caused by adding support for phpDocumentor/ReflectionDocBlock 5.4+ where the `use_short_name` config option would not function properly (see #159). **Note:** This bumps the minimum requirement for phpdocumentor/reflection-docblock to 5.4 as it leans on the PHPStan classes introduced in that version.