### PR TITLE
FEATURE: Switch to collections over type union statements to correct issues with VSCode and Silverstripe 5.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Please note, this example omitted any possible modules you require yourself!
  * @property int $Version
  * @property int $AuthorID
  * @method \SilverStripe\Security\Member Author()
- * @method \SilverStripe\ORM\DataList|Category[] Categories()
- * @method \SilverStripe\ORM\ManyManyList|Tag[] Tags()
+ * @method \SilverStripe\ORM\DataList<Category> Categories()
+ * @method \SilverStripe\ORM\ManyManyList<Tag> Tags()
  * @mixin Versioned
  */
 class NewsItem extends \SilverStripe\ORM\DataObject

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^8.0",
         "silverstripe/framework": "^4 || ^5",
-        "phpdocumentor/reflection-docblock": "^5"
+        "phpdocumentor/reflection-docblock": "^5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/docs/en/Installation.md
+++ b/docs/en/Installation.md
@@ -81,3 +81,21 @@ SilverLeague\IDEAnnotator\DataObjectAnnotator:
 - Using short names, will also shorten core names like `ManyManyList`, you'll have to adjust your use statements to work.
 
 - If you change the usage of short names halfway in your project, you may need to clear out all your docblocks before regenerating
+
+
+
+
+If you don't want to use collections for DataLists and instead use type union statements, you can disable collections like so:
+
+```yaml
+
+---
+Only:
+    environment: 'dev'
+---
+SilverLeague\IDEAnnotator\DataObjectAnnotator:
+    enabled: true
+    use_collections_for_datalist: false
+    enabled_modules:
+      - mysite
+```

--- a/src/DataObjectAnnotator.php
+++ b/src/DataObjectAnnotator.php
@@ -70,6 +70,14 @@ class DataObjectAnnotator
     private static $enabled_modules = ['mysite', 'app'];
 
     /**
+     * @config
+     * Whether to use collection syntax for DataLists instead of type unions
+     *
+     * @var bool
+     */
+    private static $use_collections_for_datalist = true;
+
+    /**
      * @var AnnotatePermissionChecker
      */
     private $permissionChecker;

--- a/src/Generators/OrmTagGenerator.php
+++ b/src/Generators/OrmTagGenerator.php
@@ -151,7 +151,12 @@ class OrmTagGenerator extends AbstractTagGenerator
                 $listName = $this->getAnnotationClassName($listType);
                 $dataObjectName = $this->getAnnotationClassName($dataObjectName);
 
-                $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
+                if (DataObjectAnnotator::config()->get('use_collections_for_datalist')) {
+                    $tagString = "{$listName}<{$dataObjectName}> {$fieldName}()";
+                } else {
+                    $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
+                }
+
                 $this->pushMethodTag($fieldName, $tagString);
             }
         }


### PR DESCRIPTION
With Silverstripe 5.2+ it appears that due to the return type definition changes they've made through the core the old style of using type unions `\SilverStripe\ORM\DataList|\Namespace\Path\Competency[]` for DataLists appears to be causing issues with VSCode (at least with intelephense). It seems vscode resolves the current syntax to (or at least intelephense does) `@return \SilverStripe\ORM\DataList<array-key, \Namespace\Path\SurveyCompetency>`.

Switching to collection style syntax (`\SilverStripe\ORM\DataList<\Namespace\Path\Competency>`) appears to fix the issue. This adds a new config option to DataObjectAnnotator "use_collections_for_datalist" that is true by default. 

![image](https://github.com/silverleague/silverstripe-ideannotator/assets/1391558/48d7f58e-6d44-4b1a-a424-faafd1267443)

vs with the change:
![image](https://github.com/silverleague/silverstripe-ideannotator/assets/1391558/db6aa06c-1188-4171-8fc5-f53440a30b87)

This could also be defaulted to false, if you feel like it makes more sense that way. This is also intended to be a follow up to #160 as it has those changes in it as well.
