### PR TITLE
Treat SilverStripe\Core\Extension the same as the deprecated SilverStripe\ORM\DataExtension class

### DIFF
--- a/src/DataObjectAnnotator.php
+++ b/src/DataObjectAnnotator.php
@@ -63,7 +63,7 @@ class DataObjectAnnotator
     /**
      * @config
      * Enable modules that are allowed to have generated docblocks for
-     * DataObjects and DataExtensions
+     * DataObjects and Extensions
      *
      * @var array
      */

--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -120,7 +120,7 @@ abstract class AbstractTagGenerator
     }
 
     /**
-     * Generate the mixins for DataExtensions.
+     * Generate the mixins for Extensions.
      */
     protected function generateExtensionsTags()
     {

--- a/src/Generators/OrmTagGenerator.php
+++ b/src/Generators/OrmTagGenerator.php
@@ -10,8 +10,8 @@ use SilverStripe\ORM\ManyManyList;
 
 /**
  * OrmTagGenerator
- * This class generates DocBlock Tags for the ORM properties of a Dataobject of DataExtension
- * and adds $owner Tags for added DataExtensions
+ * This class generates DocBlock Tags for the ORM properties of a Dataobject of Extension
+ * and adds $owner Tags for added Extensions
  *
  * @package IDEAnnotator/Generators
  */

--- a/src/Helpers/AnnotatePermissionChecker.php
+++ b/src/Helpers/AnnotatePermissionChecker.php
@@ -10,7 +10,6 @@ use SilverStripe\Control\Director;
 use SilverStripe\Core\Extension;
 use SilverStripe\Core\Injector\Injector;
 use SilverStripe\Core\Manifest\ModuleManifest;
-use SilverStripe\ORM\DataExtension;
 use SilverStripe\ORM\DataObject;
 
 /**
@@ -31,7 +30,7 @@ class AnnotatePermissionChecker
      */
     protected $supportedParentClasses = [
         DataObject::class,
-        DataExtension::class,
+        Extension::class,
         Controller::class,
         Extension::class
     ];
@@ -65,7 +64,7 @@ class AnnotatePermissionChecker
     }
 
     /**
-     * Check if a DataObject or DataExtension subclass is allowed by checking if the file
+     * Check if a DataObject or Extension subclass is allowed by checking if the file
      * is in the $allowed_modules array
      * The permission is checked by matching the filePath and modulePath
      *

--- a/tests/mock/DataObjectAnnotatorTest_Team_Extension.php
+++ b/tests/mock/DataObjectAnnotatorTest_Team_Extension.php
@@ -2,10 +2,10 @@
 
 namespace SilverLeague\IDEAnnotator\Tests;
 
+use SilverStripe\Core\Extension;
 use SilverStripe\Dev\TestOnly;
-use SilverStripe\ORM\DataExtension;
 
-class Team_Extension extends DataExtension implements TestOnly
+class Team_Extension extends Extension implements TestOnly
 {
     private static $db = array(
         'ExtendedVarcharField' => 'Varchar',

--- a/tests/unit/DataObjectAnnotatorTest.php
+++ b/tests/unit/DataObjectAnnotatorTest.php
@@ -346,9 +346,9 @@ class DataObjectAnnotatorTest extends SapphireTest
     }
 
     /**
-     * Test the generation of annotations for a DataExtension
+     * Test the generation of annotations for a Extension
      */
-    public function testAnnotateDataExtension()
+    public function testAnnotateExtension()
     {
         $classInfo = new AnnotateClassInfo(Team_Extension::class);
         $filePath = $classInfo->getClassFilePath();
@@ -369,9 +369,9 @@ class DataObjectAnnotatorTest extends SapphireTest
     }
 
     /**
-     * Test the generation of annotations for a DataExtension
+     * Test the generation of annotations for a Extension
      */
-    public function testShortAnnotateDataExtension()
+    public function testShortAnnotateExtension()
     {
         Config::modify()->set(DataObjectAnnotator::class, 'use_short_name', true);
 


### PR DESCRIPTION
Silverstripe 5.3 officially deprecates the `SilverStripe\ORM\DataExtension` in favor of just using `SilverStripe\Core\Extension` and is removed in Silverstripe 6. It seems that `DataExtension` has been redundant for sometime so this shouldn't be a breaking change.