### PR TITLE
support generics

### DIFF
--- a/src/Generators/OrmTagGenerator.php
+++ b/src/Generators/OrmTagGenerator.php
@@ -144,6 +144,8 @@ class OrmTagGenerator extends AbstractTagGenerator
      */
     protected function generateTagsForDataLists($fields, $listType = DataList::class)
     {
+        $useGenerics = DataObjectAnnotator::config()->get('use_generics');
+
         if (!empty($fields)) {
             foreach ((array)$fields as $fieldName => $dataObjectName) {
                 $fieldName = trim($fieldName);
@@ -155,7 +157,11 @@ class OrmTagGenerator extends AbstractTagGenerator
                 $listName = $this->getAnnotationClassName($listType);
                 $dataObjectName = $this->getAnnotationClassName($dataObjectName);
 
-                $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
+                if ($useGenerics) {
+                    $tagString = "{$listName}<$dataObjectName> {$fieldName}()";
+                } else {
+                    $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
+                }
                 $this->pushMethodTag($fieldName, $tagString);
             }
         }

--- a/src/Generators/OrmTagGenerator.php
+++ b/src/Generators/OrmTagGenerator.php
@@ -157,10 +157,9 @@ class OrmTagGenerator extends AbstractTagGenerator
                 $listName = $this->getAnnotationClassName($listType);
                 $dataObjectName = $this->getAnnotationClassName($dataObjectName);
 
+                $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
                 if ($useGenerics) {
                     $tagString = "{$listName}<$dataObjectName> {$fieldName}()";
-                } else {
-                    $tagString = "{$listName}|{$dataObjectName}[] {$fieldName}()";
                 }
                 $this->pushMethodTag($fieldName, $tagString);
             }


### PR DESCRIPTION
helps with https://github.com/silverleague/silverstripe-ideannotator/issues/170

this allows to get \SilverStripe\ORM\DataList<\MyObject> MyObjects() notation and is, currently, only enabled if you want it in the yml config to avoid side effects on older projects