### PR TITLE
FIX: Fix crash when an extension is set to null by the config layer

### DIFF
--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -124,7 +124,7 @@ abstract class AbstractTagGenerator
      */
     protected function generateExtensionsTags()
     {
-        if ($fields = (array)$this->getClassConfig('extensions')) {
+        if ($fields = array_filter((array)$this->getClassConfig('extensions'))) {
             foreach ($fields as $fieldName) {
                 $mixinName = $this->getAnnotationClassName($fieldName);
                 $this->pushMixinTag($mixinName);


### PR DESCRIPTION
Extensions can be set to null in yaml configs to remove an extension this causes IDEAnnotator to throw an error.

For example when a module defines an extension like:
```yaml
PageController:
  extensions:
    FontAwesomeIconPicker: 'BucklesHusky\FontAwesomeIconPicker\Extensions\PageControllerExtension'
```

It can also be removed by doing the following in the site's config, in addition to removing it through php:
```yaml
PageController:
  extensions:
    FontAwesomeIconPicker: null
```