### PR TITLE
FIX: make order more predicable in AbstractTagGenerator::generateExtensionsTags

### DIFF
--- a/src/Generators/AbstractTagGenerator.php
+++ b/src/Generators/AbstractTagGenerator.php
@@ -125,6 +125,7 @@ abstract class AbstractTagGenerator
     protected function generateExtensionsTags()
     {
         if ($fields = array_filter((array)$this->getClassConfig('extensions'))) {
+            sort($fields);
             foreach ($fields as $fieldName) {
                 $mixinName = $this->getAnnotationClassName($fieldName);
                 $this->pushMixinTag($mixinName);
@@ -133,6 +134,7 @@ abstract class AbstractTagGenerator
         if (is_subclass_of($this->className, DataObject::class)) {
             $baseFields = Config::inst()->get(DataObject::class, 'extensions', Config::UNINHERITED);
             if ($baseFields) {
+                sort($baseFields);
                 foreach ($baseFields as $fieldName) {
                     $mixinName = $this->getAnnotationClassName($fieldName);
                     $this->pushMixinTag($mixinName);


### PR DESCRIPTION


We found that two installs of Ubuntu 24.04 get different orders for docblocks - leading to meaningless changes in MANY files when you run this module. I am keen to reduce this so I tried to give this a go.

AI explanation:

_AbstractTagGenerator::generateExtensionsTags calls Config::inst()->get($this->className, 'extensions', Config::UNINHERITED). The order of that array depends on how SilverStripe's YAML config was merged — and that merge order is determined by the before/after priority directives across all your YAML files, plus the order in which modules were discovered on disk.
File system directory scanning (e.g. glob()) is not guaranteed to be in the same order across different operating systems or even different machines running the same OS. On Linux it depends on the filesystem (ext4 returns files in hash order, not alphabetical). On macOS it's typically alphabetical. So two developers on different machines can get different YAML load orders, producing different extension merge orders, producing different @mixin tag orders.
The fix is to sort the extensions before iterating. In generateExtensionsTags():_
